### PR TITLE
Bounds

### DIFF
--- a/src/calc.rs
+++ b/src/calc.rs
@@ -233,18 +233,9 @@ pub fn main(pool: r2d2::Pool<r2d2_postgres::PostgresConnectionManager<postgres::
 
     println!("\nok - done calculating coverage geometry");
 
-    let covered: f64 = match db.query(format!("
-        SELECT
-        FROM
-            country_{iso}.{iso}_geom
-    ", iso = &iso).as_str(), &[]) {
-        Err(err) => panic!("{}", err),
-        Ok(res) => res.get(0).unwrap().get(0)
-    };
-
     let (covered, uncovered): (f64, f64) = match db.query(format!("
         SELECT
-            SUM(pop * coverage * 0.01)
+            SUM(pop * coverage * 0.01),
             SUM(pop) - SUM(pop * coverage * 0.01)
         FROM
             country_{iso}.{iso}_geom

--- a/src/calc.rs
+++ b/src/calc.rs
@@ -36,7 +36,25 @@ pub fn main(pool: r2d2::Pool<r2d2_postgres::PostgresConnectionManager<postgres::
             );
             poly.index(&mut db);
 
-            println!("ok - imported {} bounds", poly.count(&mut db));
+            match db.query("
+                SELECT
+                    count(*)
+                FROM
+                    bounds
+                WHERE
+                    name = ''
+            ", &[]) {
+                Ok(res) => {
+                    let count = poly.count(&mut db);
+                    let named: i64 = res.get(0).unwrap().get(0);
+                    println!("ok - imported {}/{} bounds", named, count);
+
+                    if count > 0 && named == 0 {
+                        panic!("Bounds features must have 'name' property to be included");
+                    }
+                },
+                _ => panic!("Bounds integretiy check failed")
+            };
         },
         None => ()
     };

--- a/src/calc.rs
+++ b/src/calc.rs
@@ -22,6 +22,13 @@ pub fn main(pool: r2d2::Pool<r2d2_postgres::PostgresConnectionManager<postgres::
     let country = Country::new(format!("country_{}.country", &iso));
     println!("ok - formatted database");
 
+    match args.value_of("bounds") {
+        Some(bounds) => {
+            println!("BOUNDS")
+        },
+        None => ()
+    };
+
     let mut manager = Vec::with_capacity(2);
     {
         let mut db = pool.get().unwrap();

--- a/src/calc.rs
+++ b/src/calc.rs
@@ -36,7 +36,7 @@ pub fn main(pool: r2d2::Pool<r2d2_postgres::PostgresConnectionManager<postgres::
             );
             poly.index(&mut db);
 
-            println!("ok - imported {} bounds", poly.count());
+            println!("ok - imported {} bounds", poly.count(&mut db));
         },
         None => ()
     };
@@ -239,7 +239,7 @@ pub fn main(pool: r2d2::Pool<r2d2_postgres::PostgresConnectionManager<postgres::
     println!("Covered: {}", covered);
     println!("Uncovered: {}", uncovered);
 
-    if poly.count() > 0 {
+    if poly.count(&mut db) > 0 {
         let covered: f64 = match db.query(format!("
             SELECT
                 country_{iso}.name,

--- a/src/calc.rs
+++ b/src/calc.rs
@@ -36,21 +36,21 @@ pub fn main(pool: r2d2::Pool<r2d2_postgres::PostgresConnectionManager<postgres::
             );
             poly.index(&mut db);
 
-            match db.query("
+            match db.query(format!("
                 SELECT
                     count(*)
                 FROM
-                    bounds
+                    country_{}.bounds
                 WHERE
                     name = ''
-            ", &[]) {
+            ", &iso).as_str(), &[]) {
                 Ok(res) => {
                     let count = poly.count(&mut db);
-                    let named: i64 = res.get(0).unwrap().get(0);
-                    println!("ok - imported {}/{} bounds", named, count);
+                    let unnamed: i64 = res.get(0).unwrap().get(0);
+                    println!("ok - imported {}/{} bounds", count - unnamed, count);
 
-                    if count > 0 && named == 0 {
-                        panic!("Bounds features must have 'name' property to be included");
+                    if count > 0 && count - unnamed == 0 {
+                        panic!("not ok - bounds features must have 'name' property to be included");
                     }
                 },
                 _ => panic!("Bounds integretiy check failed")

--- a/src/calc.rs
+++ b/src/calc.rs
@@ -256,7 +256,7 @@ pub fn main(pool: r2d2::Pool<r2d2_postgres::PostgresConnectionManager<postgres::
             SELECT
                 bounds.name,
                 SUM(pop * coverage * 0.01),
-                SUM(country.pop * country.coverage * 0.01)
+                SUM(pop) - SUM(pop * coverage * 0.01)
             FROM
                 country_{iso}.{iso}_geom AS country,
                 country_{iso}.bounds AS bounds

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -81,6 +81,12 @@ subcommands:
                 help: Specify the ISO 3166-alpha2 code of the country for the calculation
                 takes_value: true
                 required: true
+            - bounds:
+                long: bounds
+                value_name: BOUNDS
+                help: Specify a file of line-delimited GeoJSON polygons to calculate RAI within
+                takes_value: true
+                required: false
             - NETWORK:
                 help: The base geospatial road network
                 required: true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod filter;
 
 pub use text::Tokenized;
 pub use text::Tokens;
+pub use types::polygon::Polygon;
 pub use types::context::Context;
 pub use types::name::Source;
 pub use types::name::Name;

--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -7,6 +7,8 @@ use serde_json::Value;
 pub mod network;
 pub mod country;
 pub mod stream;
+pub mod polygon;
+pub use self::polygon::Polygon;
 pub use self::network::Network;
 pub use self::country::Country;
 

--- a/src/pg/polygon.rs
+++ b/src/pg/polygon.rs
@@ -1,0 +1,86 @@
+use postgres::Client;
+use std::io::Read;
+use super::{Table, InputTable};
+
+///
+/// Polygon table are special in that they don't make assumptions about the underlying
+/// data. They can be any one of a number of types - building polys, parcels, places
+///
+pub struct Polygon {
+    name: String
+}
+
+impl Polygon {
+    pub fn new(name: impl ToString) -> Self {
+        Polygon {
+            name: name.to_string()
+        }
+    }
+}
+
+impl Table for Polygon {
+    fn create(&self, conn: &mut Client) {
+        conn.execute(r#"
+             CREATE EXTENSION IF NOT EXISTS POSTGIS
+        "#, &[]).unwrap();
+
+        conn.execute(format!(r#"
+            DROP TABLE IF EXISTS {};
+        "#, &self.name).as_str(), &[]).unwrap();
+
+        conn.execute(format!(r#"
+            CREATE UNLOGGED TABLE {} (
+                id BIGINT,
+                props JSONB,
+                geom GEOMETRY(MultiPolygon, 4326)
+            )
+        "#, &self.name).as_str(), &[]).unwrap();
+    }
+
+    fn count(&self, conn: &mut Client) -> i64 {
+        match conn.query(format!(r#"
+            SELECT count(*) FROM {}
+        "#, &self.name).as_str(), &[]) {
+            Ok(res) => {
+                let cnt: i64 = res.get(0).unwrap().get(0);
+                cnt
+            },
+            _ => 0
+        }
+    }
+
+    fn index(&self, conn: &mut Client) {
+        conn.execute(format!(r#"
+            CREATE INDEX {name}_idx ON {name} (id);
+        "#, name = &self.name).as_str(), &[]).unwrap();
+
+        conn.execute(format!(r#"
+            CREATE INDEX {name}_gix ON {name} USING GIST (geom);
+        "#, name = &self.name).as_str(), &[]).unwrap();
+    }
+}
+
+impl InputTable for Polygon {
+    fn input(&self, conn: &mut Client, mut data: impl Read) {
+        let stmt = conn.prepare(format!(r#"
+            COPY {} (
+                props,
+                geom
+            )
+            FROM STDIN
+            WITH (
+                FORMAT CSV,
+                NULL '',
+                DELIMITER E'\t',
+                QUOTE E'\b'
+            )
+        "#, &self.name).as_str()).unwrap();
+
+        stmt.copy_in(&[], &mut data).unwrap();
+
+        conn.execute(format!(r#"
+            UPDATE {name}
+                SET geom = ST_CollectionExtract(ST_MakeValid(geom), 3)
+        "#, name = &self.name).as_str(), &[]).unwrap();
+    }
+}

--- a/src/pg/polygon.rs
+++ b/src/pg/polygon.rs
@@ -31,6 +31,7 @@ impl Table for Polygon {
         conn.execute(format!(r#"
             CREATE UNLOGGED TABLE {} (
                 id BIGINT,
+                name TEXT,
                 props JSONB,
                 geom GEOMETRY(MultiPolygon, 4326)
             )
@@ -109,7 +110,9 @@ impl InputTable for Polygon {
 
         conn.execute(format!(r#"
             UPDATE {name}
-                SET geom = ST_CollectionExtract(ST_MakeValid(geom), 3)
+                SET
+                    geom = ST_CollectionExtract(ST_MakeValid(geom), 3),
+                    name = COALESCE(props->>'name', '')
         "#, name = &self.name).as_str(), &[]).unwrap();
     }
 }

--- a/src/pg/polygon.rs
+++ b/src/pg/polygon.rs
@@ -73,12 +73,18 @@ impl Table for Polygon {
 
     fn index(&self, conn: &mut Client) {
         conn.execute(format!(r#"
-            CREATE INDEX {name}_idx ON {name} (id);
-        "#, name = &self.name).as_str(), &[]).unwrap();
+            CREATE INDEX {}_idx ON {} (id);
+        "#,
+            &self.name.replace(".", "_"),
+            name = &self.name
+        ).as_str(), &[]).unwrap();
 
         conn.execute(format!(r#"
-            CREATE INDEX {name}_gix ON {name} USING GIST (geom);
-        "#, name = &self.name).as_str(), &[]).unwrap();
+            CREATE INDEX {}_gix ON {} USING GIST (geom);
+        "#,
+            &self.name.replace(".", "_"),
+            name = &self.name
+        ).as_str(), &[]).unwrap();
     }
 }
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,5 +1,7 @@
 pub mod geo;
 pub mod net;
+pub mod poly;
 
+pub use self::poly::PolyStream;
 pub use self::geo::GeoStream;
 pub use self::net::NetStream;

--- a/src/stream/poly.rs
+++ b/src/stream/poly.rs
@@ -1,0 +1,93 @@
+use std::convert::From;
+use std::iter::Iterator;
+use std::io::{Write, BufWriter};
+use std::fs::File;
+use crate::Polygon;
+
+use crate::stream::geo::GeoStream;
+
+pub struct PolyStream {
+    input: GeoStream,
+    buffer: Option<Vec<u8>>, //Used by Read impl for storing partial features
+    errors: Option<BufWriter<File>>
+}
+
+impl PolyStream {
+    pub fn new(input: GeoStream, errors: Option<String>) -> Self {
+        PolyStream {
+            input: input,
+            buffer: None,
+            errors: match errors {
+                None => None,
+                Some(path) => Some(BufWriter::new(File::create(path).unwrap()))
+            }
+        }
+    }
+}
+
+impl std::io::Read for PolyStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let buf_len = buf.len();
+        let mut write: Vec<u8> = Vec::new();
+        let mut end = false;
+
+        while write.len() < buf_len && !end {
+            if self.buffer.is_some() {
+                write = self.buffer.take().unwrap();
+            } else {
+                let feat = match self.next() {
+                    Some(feat) => feat.to_tsv(),
+                    None => String::from("")
+                };
+
+                let mut bytes = feat.into_bytes();
+                if bytes.len() == 0 {
+                    end = true;
+                } else {
+                    write.append(&mut bytes);
+                }
+
+                if write.len() == 0 {
+                    return Ok(0);
+                }
+            }
+        }
+
+        if write.len() > buf_len {
+            self.buffer = Some(write.split_off(buf_len));
+        }
+
+        for it in 0..write.len() {
+            buf[it] = write[it];
+        }
+
+        Ok(write.len())
+    }
+}
+
+impl Iterator for PolyStream {
+    type Item = Polygon;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut next: Result<Polygon, String> = Err(String::from(""));
+
+        while next.is_err() {
+            next = match self.input.next() {
+                Some(potential) => match Polygon::new(potential) {
+                    Ok(potential) => Ok(potential),
+                    Err(err) => match self.errors {
+                        None => Err(err),
+                        Some(ref mut file) => {
+                            file.write(format!("{}\n", err).as_bytes()).unwrap();
+
+                            Err(err)
+                        }
+                    }
+                },
+                None => { return None; }
+            };
+        }
+
+        Some(next.unwrap())
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,6 +1,7 @@
 pub mod net;
 pub mod context;
 pub mod name;
+pub mod polygon;
 pub use net::Network;
 
 pub trait AsTSV {

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -1,0 +1,93 @@
+use postgis::ewkb::EwkbWrite;
+
+///
+/// A representation of a single polygon
+///
+#[derive(Debug)]
+pub struct Polygon {
+    /// An optional identifier for the address
+    pub id: Option<i64>,
+
+    /// JSON representation of properties
+    pub props: serde_json::Map<String, serde_json::Value>,
+
+    /// Simple representation of Lng/Lat geometry
+    pub geom: Vec<geojson::PolygonType>
+}
+
+impl Polygon {
+    pub fn new(feat: geojson::GeoJson) -> Result<Self, String> {
+        let feat = match feat {
+            geojson::GeoJson::Feature(feat) => feat,
+            _ => { return Err(String::from("Not a GeoJSON Feature")); }
+        };
+
+        let props = match feat.properties {
+            Some(props) => props,
+            None => { return Err(String::from("Feature has no properties")); }
+        };
+
+        let geom = match feat.geometry {
+            Some(geom) => match geom.value {
+                geojson::Value::Polygon(py) => vec![py],
+                geojson::Value::MultiPolygon(mpy) => mpy,
+                _ => { return Err(String::from("Polygon must have (Multi)Polygon geometry")); }
+            },
+            None => { return Err(String::from("Polygon must have geometry")); }
+        };
+
+        Ok(Polygon {
+            id: match feat.id {
+                Some(geojson::feature::Id::Number(id)) => id.as_i64(),
+                _ => None
+            },
+            props: props,
+            geom: geom
+        })
+    }
+
+    ///
+    /// Return a PG Copyable String of the feature
+    /// props, geom
+    ///
+    pub fn to_tsv(self) -> String {
+        let mut twkb = postgis::twkb::MultiPolygon {
+            polygons: Vec::with_capacity(self.geom.len()),
+            ids: None
+        };
+
+        for py in self.geom {
+            let mut poly = postgis::twkb::Polygon {
+                rings: Vec::with_capacity(py.len())
+            };
+
+            for py_ring in py {
+                let mut ring = postgis::twkb::LineString {
+                    points: Vec::with_capacity(py_ring.len())
+                };
+
+                for pt in py_ring {
+                    ring.points.push(postgis::twkb::Point {
+                        x: pt[0],
+                        y: pt[1],
+                    });
+                }
+
+                poly.rings.push(ring);
+            }
+
+            twkb.polygons.push(poly);
+        }
+
+        let geom = postgis::ewkb::EwkbMultiPolygon {
+            geom: &twkb,
+            srid: Some(4326),
+            point_type: postgis::ewkb::PointType::Point
+        }.to_hex_ewkb();
+
+        format!("{props}\t{geom}\n",
+            props = serde_json::value::Value::from(self.props),
+            geom = geom
+        )
+    }
+}


### PR DESCRIPTION
This PR introduces a `--bounds` flag to the `calc` module.

Provided a `name` property is provided, this will calculate RAI for arbitrary (multi)polygons.

Closes: https://github.com/developmentseed/rai-toolkit/issues/2

cc/ @geohacker 