### PR TITLE
Docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# ignore .git and .cache folders
+.git
+.cache
+postgres-data/
+data/
+
+# ignore all *.class files in all folders, including build root
+
+# ignore all markdown files (md) beside all README*.md
+*.md
+!README*.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 *.geojson
 *.geojsonld
+postgres-data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN curl 'https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-x64.tar.gz' | tar
     && ./node-v12.18.1-linux-x64/bin/npm install -g npm \
     && npm install -g yarn
 
-COPY ./ $HOME/toolkit
+COPY . $HOME/toolkit/
 WORKDIR $HOME/toolkit
 
 RUN cd web \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM ubuntu:20.04
 
 EXPOSE 4001
 ENV HOME=/home/rai
-COPY ./ $HOME/toolkit
-WORKDIR $HOME/toolkit
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
@@ -28,8 +26,12 @@ RUN cd ${HOME} \
 RUN curl 'https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-x64.tar.gz' | tar -xzv \
     && cp ./node-v12.18.1-linux-x64/bin/node /usr/bin/ \
     && ./node-v12.18.1-linux-x64/bin/npm install -g npm \
-    && npm install -g yarn \
-    && cd web \
+    && npm install -g yarn
+
+COPY ./ $HOME/toolkit
+WORKDIR $HOME/toolkit
+
+RUN cd web \
     && yarn install \
     && yarn build
 
@@ -37,6 +39,9 @@ ENV PATH="$HOME/.cargo/bin:${PATH}"
 
 RUN cargo build --release \
     && cp ${HOME}/toolkit/target/release/rai-toolkit /usr/bin/
+
+VOLUME /var/lib/postgresql/data
+EXPOSE 5432
 
 CMD service postgresql start \
     && tail -f /dev/null

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,8 @@ RUN apt-get update \
     && ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime \
     && apt-get install -y tzdata \
     && dpkg-reconfigure --frontend noninteractive tzdata \
-    && apt-get install -y curl build-essential postgresql postgresql-postgis postgis libssl-dev pkg-config \
+    && apt-get install -y curl build-essential libssl-dev pkg-config \
     && apt-get install -y gdal-bin jq \
-    && echo "local   all     all     trust" > /etc/postgresql/12/main/pg_hba.conf \
-    && echo "host    all     all     localhost       trust" >> /etc/postgresql/12/main/pg_hba.conf \
-    && echo "host    all     all     127.0.0.1/32    trust" >> /etc/postgresql/12/main/pg_hba.conf \
-    && echo "host    all     all     ::1/128         trust" >> /etc/postgresql/12/main/pg_hba.conf \
-    && echo "host    all     all     0.0.0.0/0       trust" >> /etc/postgresql/12/main/pg_hba.conf \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs 0.43 | sh -s -- -y
 
 RUN cd ${HOME} \
@@ -40,8 +35,5 @@ ENV PATH="$HOME/.cargo/bin:${PATH}"
 RUN cargo build --release \
     && cp ${HOME}/toolkit/target/release/rai-toolkit /usr/bin/
 
-VOLUME /var/lib/postgresql/data
-EXPOSE 5432
-
-CMD service postgresql start \
-    && tail -f /dev/null
+# CMD service postgresql start \
+#     && tail -f /dev/null

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     && apt-get install -y tzdata \
     && dpkg-reconfigure --frontend noninteractive tzdata \
     && apt-get install -y curl build-essential libssl-dev pkg-config \
-    && apt-get install -y gdal-bin jq \
+    && apt-get install -y gdal-bin jq postgresql-contrib \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs 0.43 | sh -s -- -y
 
 RUN cd ${HOME} \
@@ -34,6 +34,3 @@ ENV PATH="$HOME/.cargo/bin:${PATH}"
 
 RUN cargo build --release \
     && cp ${HOME}/toolkit/target/release/rai-toolkit /usr/bin/
-
-# CMD service postgresql start \
-#     && tail -f /dev/null

--- a/README.md
+++ b/README.md
@@ -21,12 +21,7 @@ A raster population dataset is required to be loaded before any RAI calculations
 - Select the appropriate grid size
 - Download the zip file following the link
 - Unzip the archive
-
-Then, if using docker, use `docker cp` to copy the files into the running docker container by running the following command your terminal:
-
-```
-docker cp path-to-population-data-folder/ rai:/
-```
+- Save them on `rai-toolkit/<path-to-nasa-data-folder>` folder
 
 Once the files are available, run:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  rai:
+    image: developmentseed/rai:v1
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+      - ./:/home/rai/toolkit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,14 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    environment:
+      POSTGRES_HOST: 'localhost'
+      POSTGRES_DB: 'rai'
+      POSTGRES_USER: 'postgres'
+      POSTGRES_PASSWORD: '1234'
     ports:
       - "5432:5432"
+      - "4001:4001"
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
       - ./:/home/rai/toolkit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,16 @@
 version: '3'
 services:
   db:
-    image: mdillon/postgis:11
+    build:
+      context: ./dockerPG
+      dockerfile: Dockerfile
     environment:
       POSTGRES_HOST: 'db'
       POSTGRES_DB: 'rai'
       POSTGRES_USER: 'postgres'
       POSTGRES_PASSWORD: '1234'
+      SET_SERVER_CONFING: 'true'
+      MACHINE_TYPE: 'xlarge'
     ports:
       -  "5432:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,27 @@
 version: '3'
 services:
+  db:
+    image: mdillon/postgis:11
+    environment:
+      POSTGRES_HOST: 'db'
+      POSTGRES_DB: 'rai'
+      POSTGRES_USER: 'postgres'
+      POSTGRES_PASSWORD: '1234'
+    ports:
+      -  "5432:5432"
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
   rai:
     image: developmentseed/rai:v1
     build:
       context: .
       dockerfile: Dockerfile
     environment:
-      POSTGRES_HOST: 'localhost'
+      POSTGRES_HOST: 'db'
       POSTGRES_DB: 'rai'
       POSTGRES_USER: 'postgres'
       POSTGRES_PASSWORD: '1234'
     ports:
-      - "5432:5432"
       - "4001:4001"
     volumes:
-      - ./postgres-data:/var/lib/postgresql/data
       - ./:/home/rai/toolkit

--- a/dockerPG/Dockerfile
+++ b/dockerPG/Dockerfile
@@ -1,0 +1,4 @@
+FROM mdillon/postgis:11
+RUN apt-get update
+RUN mkdir -p /docker-entrypoint-initdb.d
+COPY ./config/server_config.sh /docker-entrypoint-initdb.d/

--- a/dockerPG/README.md
+++ b/dockerPG/README.md
@@ -1,0 +1,21 @@
+# Postgres configuration
+
+This short documentation for improving the DB performance in RAI transactions.
+
+Refs:
+
+- https://www.postgresql.org/docs/11/runtime-config-resource.html
+- https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server
+
+# Available configuration
+
+Make sure your docker resource configuration has available resources to support it.
+
+- xlarge: CPU 4 and RAM 8GB
+- 4xlarge: CPU 16 and RAM 32GB
+- 2xlarge: CPU 8 and RAM 32GB
+
+For selecting the configuration for machine type you should be set on the `docker-compose.yaml` file
+
+- SET_SERVER_CONFING: true
+- MACHINE_TYPE: xlarge

--- a/dockerPG/config/server_config.sh
+++ b/dockerPG/config/server_config.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+set -e
+
+if [ "$SET_SERVER_CONFING" = "true" ]; then 
+    # Configuration for a machine 8GB RAM and 4 CPU
+    if [ "$MACHINE_TYPE" = "xlarge" ]; then 
+        shared_buffers=3GB
+        effective_cache_size=9GB
+        maintenance_work_mem=768MB
+        checkpoint_completion_target=0.7
+        wal_buffers=16MB
+        default_statistics_target=100
+        random_page_cost=1.1
+        effective_io_concurrency=200
+        work_mem=78643kB
+        min_wal_size=1GB
+        max_wal_size=4GB
+        max_worker_processes=4
+        max_parallel_workers_per_gather=2
+        max_parallel_workers=4
+        max_parallel_maintenance_workers=2
+    fi
+    # Configuration for a machine 32GB RAM and 16 CPU
+    if [ "$MACHINE_TYPE" = "4xlarge" ]; then 
+        shared_buffers=8GB
+        effective_cache_size=24GB
+        maintenance_work_mem=2GB
+        checkpoint_completion_target=0.9
+        wal_buffers=16MB
+        default_statistics_target=500
+        random_page_cost=1.1
+        effective_io_concurrency=200
+        work_mem=26214kB
+        min_wal_size=4GB
+        max_wal_size=16GB
+        max_worker_processes=16
+        max_parallel_workers_per_gather=8
+        max_parallel_workers=16
+        max_parallel_maintenance_workers=4
+    fi
+    # Configuration for a machine 32GB RAM and 8 CPU
+    if [ "$MACHINE_TYPE" = "2xlarge" ]; then 
+        max_connections=100
+        shared_buffers=8GB
+        effective_cache_size=24GB
+        maintenance_work_mem=2GB
+        checkpoint_completion_target=0.9
+        wal_buffers=16MB
+        default_statistics_target=500
+        random_page_cost=1.1
+        effective_io_concurrency=200
+        work_mem=10485kB
+        min_wal_size=4GB
+        max_wal_size=16GB
+        max_worker_processes=8
+        max_parallel_workers_per_gather=4
+        max_parallel_workers=8
+        max_parallel_maintenance_workers=4
+    fi
+
+    echo "Set configuration for db $MACHINE_TYPE server..."
+    echo "shared_buffers = $shared_buffers"
+    echo "effective_cache_size = $effective_cache_size"
+    echo "maintenance_work_mem = $maintenance_work_mem"
+    echo "checkpoint_completion_target = $checkpoint_completion_target"
+    echo "wal_buffers = $wal_buffers"
+    echo "default_statistics_target = $default_statistics_target"
+    echo "random_page_cost = $random_page_cost"
+    echo "effective_io_concurrency = $effective_io_concurrency"
+    echo "work_mem = $work_mem"
+    echo "min_wal_size = $min_wal_size"
+    echo "max_wal_size = $max_wal_size"
+    echo "max_worker_processes = $max_worker_processes"
+    echo "max_parallel_workers_per_gather = $max_parallel_workers_per_gather"
+    echo "max_parallel_workers = $max_parallel_workers"
+    echo "max_parallel_maintenance_workers = $max_parallel_maintenance_workers"
+    sed -i -e 's/shared_buffers = 128MB/shared_buffers = '$shared_buffers'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/#effective_cache_size = 4GB/effective_cache_size = '$effective_cache_size'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/#maintenance_work_mem = 64MB/maintenance_work_mem = '$maintenance_work_mem'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/#checkpoint_completion_target = 0.5/checkpoint_completion_target = '$checkpoint_completion_target'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/#wal_buffers = -1/wal_buffers = '$wal_buffers'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/#default_statistics_target = 100/default_statistics_target = '$default_statistics_target'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/#random_page_cost = 4.0/random_page_cost = '$random_page_cost'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/#effective_io_concurrency = 1/effective_io_concurrency = '$effective_io_concurrency'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/#work_mem = 4MB/work_mem = '$work_mem'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/max_wal_size = 1GB/max_wal_size = '$max_wal_size'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/min_wal_size = 80MB/min_wal_size = '$min_wal_size'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/#max_worker_processes = 8/max_worker_processes = '$max_worker_processes'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/#max_parallel_workers_per_gather = 2/max_parallel_workers_per_gather = '$max_parallel_workers_per_gather'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/#max_parallel_workers = 8/max_parallel_workers = '$max_parallel_workers'/g' $PGDATA/postgresql.conf
+    sed -i -e 's/#max_parallel_maintenance_workers = 2/max_parallel_maintenance_workers = '$max_parallel_maintenance_workers'/g' $PGDATA/postgresql.conf
+fi
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
     let cli_cnf = load_yaml!("cli.yml");
     let args = App::from(cli_cnf).get_matches();
 
-    let db_str = args.value_of("database").unwrap_or("postgres://postgres@localhost:5432/rai");
+    let db_str = args.value_of("database").unwrap_or("postgres://postgres:1234@db:5432/rai");
 
     let manager = PostgresConnectionManager::new(
         db_str.parse().unwrap(),

--- a/util/cache-nasa
+++ b/util/cache-nasa
@@ -18,13 +18,6 @@ fi
 
 set -euo pipefail
 
-# echo "
-#     CREATE DATABASE rai;
-# " | psql -U postgres -h db
-
-#https://gis.stackexchange.com/a/341598
-# CREATE EXTENSION postgis;
-# CREATE EXTENSION postgis_raster;
 echo "
     CREATE SCHEMA IF NOT EXISTS pop;
 " | psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB

--- a/util/cache-nasa
+++ b/util/cache-nasa
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 CC=$1
+export PGPASSWORD=$POSTGRES_PASSWORD
 
 TIMESTAMP=$(date +%s)
 
@@ -17,15 +18,16 @@ fi
 
 set -euo pipefail
 
-echo "
-    CREATE DATABASE rai;
-" | psql -U postgres
+# echo "
+#     CREATE DATABASE rai;
+# " | psql -U postgres -h db
 
+# CREATE EXTENSION postgis;
+# CREATE EXTENSION postgis_raster;
+#https://gis.stackexchange.com/a/341598
 echo "
-    CREATE EXTENSION postgis;
-    CREATE EXTENSION postgis_raster;
     CREATE SCHEMA IF NOT EXISTS pop;
-" | psql -U postgres rai
+" | psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB
 
 
 # -I Create a spatial index for imported data
@@ -38,4 +40,5 @@ raster2pgsql \
     -t auto \
     $1/*.asc pop.population \
     | tee /tmp/raster.sql \
-    | psql -U postgres rai
+    | psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB
+

--- a/util/cache-nasa
+++ b/util/cache-nasa
@@ -22,9 +22,9 @@ set -euo pipefail
 #     CREATE DATABASE rai;
 # " | psql -U postgres -h db
 
+#https://gis.stackexchange.com/a/341598
 # CREATE EXTENSION postgis;
 # CREATE EXTENSION postgis_raster;
-#https://gis.stackexchange.com/a/341598
 echo "
     CREATE SCHEMA IF NOT EXISTS pop;
 " | psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB

--- a/util/cache-osm
+++ b/util/cache-osm
@@ -26,7 +26,7 @@ if [[ $URL == "null" ]]; then
     exit 1
 fi
 
-wget $URL -O /tmp/$CC.osm.pbf
+curl $URL > /tmp/$CC.osm.pbf
 
 osmium export \
     --output-format geojsonseq \

--- a/util/cache-osm
+++ b/util/cache-osm
@@ -26,7 +26,7 @@ if [[ $URL == "null" ]]; then
     exit 1
 fi
 
-curl $URL > /tmp/$CC.osm.pbf
+wget $URL -O /tmp/$CC.osm.pbf
 
 osmium export \
     --output-format geojsonseq \
@@ -39,3 +39,4 @@ cargo run -- filter \
     > $(dirname $0)/../${CC}.geojsonld
 
 echo "ok - ./$CC.geojsonld"
+

--- a/util/cache-osm.conf
+++ b/util/cache-osm.conf
@@ -2,12 +2,20 @@
     "ca": "https://download.geofabrik.de/north-america/canada-latest.osm.pbf",
     "us": "https://download.geofabrik.de/north-america/us-latest.osm.pbf",
     "mx": "https://download.geofabrik.de/north-america/mexico-latest.osm.pbf",
-
+    
     "zm": "https://download.geofabrik.de/africa/zambia-latest.osm.pbf",
     "py": "https://download.geofabrik.de/south-america/paraguay-latest.osm.pbf",
     "dz": "https://download.geofabrik.de/africa/algeria-latest.osm.pbf",
     "ao": "https://download.geofabrik.de/africa/angola-latest.osm.pbf",
     "bj": "https://download.geofabrik.de/africa/benin-latest.osm.pbf",
     "bw": "https://download.geofabrik.de/africa/botswana-latest.osm.pbf",
-    "bf": "https://download.geofabrik.de/africa/burkina-faso-latest.osm.pbf"
+    "bf": "https://download.geofabrik.de/africa/burkina-faso-latest.osm.pbf",
+    "hn": "https://project-connect-nana-share.s3.amazonaws.com/phase_3/data/country-boundaries/honduras.pbf",
+    "rw": "http://download.geofabrik.de/africa/rwanda-latest.osm.pbf",
+    "ke": "http://download.geofabrik.de/africa/kenya-latest.osm.pbf",
+    "sl": "http://download.geofabrik.de/africa/sierra-leone-latest.osm.pbf",
+    "gh": "http://download.geofabrik.de/africa/ghana-latest.osm.pbf",
+    "ne": "http://download.geofabrik.de/africa/niger-latest.osm.pbf",
+    "kz": "http://download.geofabrik.de/asia/kazakhstan-latest.osm.pbf",
+    "uz": "http://download.geofabrik.de/asia/uzbekistan-latest.osm.pbf"
 }

--- a/util/cache-osm.conf
+++ b/util/cache-osm.conf
@@ -10,7 +10,6 @@
     "bj": "https://download.geofabrik.de/africa/benin-latest.osm.pbf",
     "bw": "https://download.geofabrik.de/africa/botswana-latest.osm.pbf",
     "bf": "https://download.geofabrik.de/africa/burkina-faso-latest.osm.pbf",
-    "hn": "https://project-connect-nana-share.s3.amazonaws.com/phase_3/data/country-boundaries/honduras.pbf",
     "rw": "http://download.geofabrik.de/africa/rwanda-latest.osm.pbf",
     "ke": "http://download.geofabrik.de/africa/kenya-latest.osm.pbf",
     "sl": "http://download.geofabrik.de/africa/sierra-leone-latest.osm.pbf",


### PR DESCRIPTION
While I was looking into the rai-toolkit. I found some points where we can improve the container using docker-compose

- Avoid using `docker cp` we can share the rai-toolkit folder with the container, so we can download the TIF and ASC files in `rai-toolkit/data/` and use it from there.

- When we stop a running container, we lose all the data, it would be better to use the image `mdillon/postgis:11`  and save the `postgres-data` folder to in the `rai-toolkit` directory, and if we stop and up the container again, we won't be lost the Db data.

- Since rai-toolkit is working with lots of data,  selecting and inserting data into the DB, it would be good to customize the values of the progress server, like this, it will be set up automatic once we run `docker-compose up db`. 


The CLI would be  like so:

- Up the DB  with `docker-compose up db`
- Access to the rai-toolkit environment with  `docker-compose run rai bash` and all local files from `rai-toolkit` directory will be available in the container and able for development too. 

cc. @ingalls @geohacker 